### PR TITLE
Update releasing/tagging logic

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -37,3 +37,4 @@ jobs:
           tag: v${{ steps.package-version.outputs.current-version}}
           commit: main
           generateReleaseNotes: true
+          draft: true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -36,5 +36,5 @@ jobs:
           name: ${{ steps.package-version.outputs.current-version}}
           tag: v${{ steps.package-version.outputs.current-version}}
           commit: main
-          generateReleaseNotes: true
+          omitBody: true
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Publish
 on:
   release:
-    types: [created, published, edited]
+    types: [published, edited]
 jobs:
   build:
     name: Build Action

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bachmacintosh/need-npm-pkg-version-bump",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "A GitHub Action that checks for a package.json version bump, and fails if it isn't a newer Semantic Version",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
- Only tag when release is published, not created
- Bump version to 1.0.4
- Automatic release will now be a draft so we can update the body ourselves